### PR TITLE
Volunteer count in chat

### DIFF
--- a/src/components/Chat/ChatHeaderComponent.tsx
+++ b/src/components/Chat/ChatHeaderComponent.tsx
@@ -15,7 +15,7 @@ interface IProps {
 }
 
 const ChatHeaderComponent = (props: IProps) => {
-  const { roomID } = props.activeChat;
+  const { roomID, volunteerCount } = props.activeChat;
   const { nickname, subject, chatType } = props.activeChat.student;
   const { socketSend, dispatchChats, uniqueID, talky } = useContext(
     SocketContext,
@@ -36,7 +36,7 @@ const ChatHeaderComponent = (props: IProps) => {
     setModalState('regular');
   };
 
-  const leaveChat = (helpResult: MixpanelEvents, eventProps: object) => {
+  const leaveChat = () => {
     dispatchChats(leaveChatAction(roomID));
     socketSend({
       msgType: MESSAGE_TYPES.LEAVE_CHAT,
@@ -46,8 +46,15 @@ const ChatHeaderComponent = (props: IProps) => {
         roomID,
       },
     });
-    MixpanelService.track(helpResult, eventProps);
     closeModals();
+  };
+
+  const leaveChatAndTrack = (
+    helpResult: MixpanelEvents,
+    eventProps: object,
+  ) => {
+    leaveChat();
+    MixpanelService.track(helpResult, eventProps);
   };
 
   const openTalky = () => {
@@ -98,7 +105,13 @@ const ChatHeaderComponent = (props: IProps) => {
         <Modal
           content="Er du sikker på at du vil forlate chatten?"
           warningButtonText="Forlat Chatten"
-          warningCallback={openFeedbackModal}
+          warningCallback={() => {
+            if (volunteerCount === 1) {
+              openFeedbackModal();
+            } else {
+              leaveChat();
+            }
+          }}
           successButtonText="Bli i Chatten"
           successCallback={closeModals}
           closingCallback={closeModals}
@@ -109,7 +122,7 @@ const ChatHeaderComponent = (props: IProps) => {
           content="Tilbakemeldingsskjema"
           successButtonText="Send inn skjema"
           warningButtonText="Avbryt"
-          successCallback={leaveChat}
+          successCallback={leaveChatAndTrack}
           warningCallback={closeModals}
           closingCallback={closeModals}
         />

--- a/src/components/Chat/ChatInputComponent.tsx
+++ b/src/components/Chat/ChatInputComponent.tsx
@@ -45,6 +45,7 @@ const ChatInputComponent = (props: IProps) => {
 
   const frivilligOptionsCallback = (volunteer: IVolunteer): void => {
     //setAvailableVolunteers(availableVolunteers.filter(vol => vol !== volunteer));
+    chats[activeChatIndex].volunteerCount += 1;
     socketSend(createGetAvailableQueueMessage(roomID));
     socketSend(
       new JoinChatMessageBuilder()

--- a/src/components/Chat/ChatMessageComponent.tsx
+++ b/src/components/Chat/ChatMessageComponent.tsx
@@ -67,9 +67,7 @@ const ChatMessageComponent = (props: IProps) => {
   if (uniqueID === 'NOTIFICATION') {
     return (
       <div className="chat-message">
-        <p className="chat-message--notification">
-          {author} {message}
-        </p>
+        <p className="chat-message--notification">{message}</p>
       </div>
     );
   } else {

--- a/src/components/Chat/ChatQueueComponent.tsx
+++ b/src/components/Chat/ChatQueueComponent.tsx
@@ -109,7 +109,7 @@ const ChatQueueComponent = (props: RouteComponentProps) => {
                     setTimeout(() => history.push('/messages'), 1000);
                   }}
                 >
-                  Åpne {chatType === LEKSEHJELP_TEXT ? 'chat' : 'videochat'}.
+                  Åpne {chatType === LEKSEHJELP_TEXT ? 'chat' : 'videochat'}
                 </button>
               </div>
             </div>

--- a/src/components/HeaderComponent.tsx
+++ b/src/components/HeaderComponent.tsx
@@ -19,7 +19,7 @@ const HeaderComponent = (props: RouteComponentProps & IProps) => {
 
   const [modalOpen, setModalOpen] = useState<boolean>(false);
 
-  const { queue } = useContext(SocketContext);
+  const { queue, chats } = useContext(SocketContext);
 
   const {
     activeState,
@@ -99,6 +99,9 @@ const HeaderComponent = (props: RouteComponentProps & IProps) => {
             }}
           >
             <Link to="/messages">Chat</Link>
+            <span className="dot">
+              {chats.reduce((sum, chat) => sum + chat.unread, 0)}
+            </span>
           </li>
           <li
             className={`header--list-item ${path === 'questions' && 'active'}`}

--- a/src/interfaces/IChat.ts
+++ b/src/interfaces/IChat.ts
@@ -5,4 +5,5 @@ export interface IChat {
   messages: ITextMessage[];
   roomID: string;
   unread: number;
+  volunteerCount: number;
 }

--- a/src/providers/SocketProvider.tsx
+++ b/src/providers/SocketProvider.tsx
@@ -215,14 +215,15 @@ export const SocketProvider: FunctionComponent = ({ children }: any) => {
           if (talky && talky.roomID === payload['roomID']) {
             setTalky(null);
           }
+          setActiveChatIndex(0);
         } else {
           action = hasLeftChatAction(
             payload['roomID'],
             payload['name'],
+            payload['volunteerCount'],
             payload['message'],
           );
         }
-        setActiveChatIndex(0);
         dispatchChats(action);
         break;
       case ERROR_LEAVING_CHAT:
@@ -236,9 +237,12 @@ export const SocketProvider: FunctionComponent = ({ children }: any) => {
         reconnectSuccessHandler(payload['roomIDs']);
         break;
       case JOIN_CHAT:
-        const student: IStudent = payload['studentInfo'];
-        const messages: ITextMessage[] = payload['chatHistory'];
-        action = joinChatAction(student, messages, payload['roomID']);
+        action = joinChatAction(
+          payload['studentInfo'],
+          payload['chatHistory'],
+          payload['roomID'],
+          payload['volunteerCount'],
+        );
         dispatchChats(action);
         break;
       case AVAILABLE_CHAT:


### PR DESCRIPTION
- Handle web sockets messages with volunteer count to ensure that feedback schema only opens for the last volunteer in the chat. 
- Add total number of unread chat messages to the volunteer's header.
- Move setActiveChatIndex in SocketProvider to fix bug which caused a volunteer's active chat window to change when another volunteer left the chat. 
- Refactor code.