### PR TITLE
Create admin page for users and AdminRoute

### DIFF
--- a/src/components/AddUserComponent.tsx
+++ b/src/components/AddUserComponent.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import Dropdown from 'react-dropdown';
+import { VolunteerRole } from '../enums/VolunteerRole';
+import { getRoleOptions } from '../services';
+import { INewUser } from '../interfaces/INewUser';
+
+interface IProps {
+  onAddUser: (user: INewUser) => void;
+}
+
+const AddUserComponent = ({ onAddUser }: IProps) => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [role, setRole] = useState<VolunteerRole | undefined>(undefined);
+
+  const clearUserFields = () => {
+    setName('');
+    setEmail('');
+    setRole(undefined);
+  };
+
+  const isValidEmail = (email: string) => {
+    return /.+@.+/.test(email);
+  };
+
+  const isValidForm = name.length > 1 && role && isValidEmail(email);
+
+  return (
+    <div className="add-users">
+      <h4 className="add-users--title">Legg til ny bruker</h4>
+      <div className="add-users--fields">
+        <input
+          className="profile-form--input add-users--item"
+          value={name}
+          name="name"
+          placeholder="Navn"
+          onChange={e => {
+            setName(e.target.value);
+          }}
+        />
+        <input
+          className="profile-form--input add-users--item"
+          value={email}
+          name="email"
+          placeholder="Epost"
+          onChange={e => {
+            setEmail(e.target.value);
+          }}
+        />
+        <div className="add-users--item">
+          <Dropdown
+            value={role}
+            className="leksehjelp--dropdown"
+            options={getRoleOptions()}
+            onChange={option => setRole(option.value as VolunteerRole)}
+            placeholder="Velg rolle"
+          />
+        </div>
+      </div>
+      <button
+        className={
+          isValidForm
+            ? 'leksehjelp--button-success add-users--button'
+            : 'leksehjelp--button-disabled add-users--button'
+        }
+        disabled={!isValidForm}
+        onClick={() => {
+          clearUserFields();
+          return role && onAddUser({ name, email, role });
+        }}
+      >
+        Legg til
+      </button>
+    </div>
+  );
+};
+
+export default AddUserComponent;

--- a/src/components/AdminRoute.tsx
+++ b/src/components/AdminRoute.tsx
@@ -1,0 +1,29 @@
+import React, { FunctionComponent, useContext } from 'react';
+import { Redirect, Route, RouteProps } from 'react-router-dom';
+import { SocketContext } from '../providers';
+import { VolunteerRole } from '../enums/VolunteerRole';
+
+interface Props extends RouteProps {
+  component: React.ComponentType<RouteProps>;
+}
+
+const AdminRoute: FunctionComponent<Props> = ({
+  component: Component,
+  ...rest
+}) => {
+  const { volunteerInfo } = useContext(SocketContext);
+  return (
+    <Route
+      {...rest}
+      render={props =>
+        volunteerInfo.role === VolunteerRole.ADMIN ? (
+          <Component {...props} />
+        ) : (
+          <Redirect to="/profile" />
+        )
+      }
+    />
+  );
+};
+
+export default AdminRoute;

--- a/src/components/Chat/ChatInputComponent.tsx
+++ b/src/components/Chat/ChatInputComponent.tsx
@@ -2,14 +2,12 @@ import React, { useContext, useState, useCallback } from 'react';
 import { useDropzone } from 'react-dropzone';
 import {
   createGetAvailableQueueMessage,
-  createVolunteerMessage,
   getTimeStringNow,
-  getVolunteer,
   JoinChatMessageBuilder,
   TextMessageBuilder,
   uploadFileToAzureBlobStorage,
 } from '../../services';
-import { IFile, ITempFile, IVolunteer } from '../../interfaces';
+import { IFile, IVolunteer } from '../../interfaces';
 import { addMessageAction } from '../../reducers';
 import { SocketContext } from '../../providers';
 import { IconButton, Modal } from '../';
@@ -30,7 +28,6 @@ const ChatInputComponent = (props: IProps) => {
     activeChatIndex,
     chats,
     uniqueID,
-    setAvailableVolunteers,
   } = useContext(SocketContext);
   const [modalOpen, setModalOpen] = useState<boolean>(false);
   const { roomID } = props;

--- a/src/components/EditUserRow.tsx
+++ b/src/components/EditUserRow.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import Dropdown from 'react-dropdown';
+import '../styles/admin-users.less';
+import { getRoleOptions } from '../services';
+import { IVolunteer } from '../interfaces';
+
+interface IProps {
+  user: IVolunteer;
+  onUpdateUser: (id: string, role: string) => void;
+  onDeleteUser: (id: string) => void;
+}
+const EditUserRow: React.FC<IProps> = ({
+  user,
+  onUpdateUser,
+  onDeleteUser,
+}) => {
+  const [role, setRole] = useState(user.role);
+
+  const handleUpdatedUser = option => {
+    setRole(option.value);
+    onUpdateUser(user.id, option.value);
+  };
+
+  return (
+    <tr>
+      <td>{user.name}</td>
+      <td>{user.email}</td>
+      <td>{user.subjects}</td>
+      <td>
+        <Dropdown
+          value={role}
+          className="leksehjelp--dropdown"
+          options={getRoleOptions()}
+          onChange={option => handleUpdatedUser(option)}
+          placeholder={role}
+        />
+      </td>
+      <td>
+        <button
+          className="leksehjelp--button--outline-warning w60"
+          onClick={() => onDeleteUser(user.id)}
+        >
+          Slett
+        </button>
+      </td>
+    </tr>
+  );
+};
+
+export default EditUserRow;

--- a/src/components/EditUsersComponent.tsx
+++ b/src/components/EditUsersComponent.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import EditUserRow from './EditUserRow';
+import '../styles/admin-users.less';
+import { IVolunteer } from '../interfaces';
+
+interface IProps {
+  users: IVolunteer[];
+  onUpdateUser: (id: string, role: string) => void;
+  onDeleteUser: (id: string) => void;
+}
+
+const EditUsersComponent: React.FC<IProps> = ({
+  users,
+  onUpdateUser,
+  onDeleteUser,
+}) => (
+  <div className="edit-users">
+    <h4 className="edit-users--title">Alle brukere</h4>
+    <table cellPadding="10">
+      <thead>
+        <tr className="edit-users--row edit-users--header">
+          <th>Navn</th>
+          <th>Brukernavn</th>
+          <th>Fag</th>
+          <th>Rolle</th>
+          <th />
+        </tr>
+      </thead>
+      <tbody>
+        {users.length >= 1 &&
+          users.map(user => (
+            <EditUserRow
+              key={user.id}
+              user={user}
+              onUpdateUser={onUpdateUser}
+              onDeleteUser={onDeleteUser}
+            />
+          ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+export default EditUsersComponent;

--- a/src/components/HeaderComponent.tsx
+++ b/src/components/HeaderComponent.tsx
@@ -5,22 +5,19 @@ import { SocketContext, StateContext } from '../providers/';
 import { Modal } from './';
 import { getIsLeksehjelpOpen, toggleIsLeksehjelpOpen } from '../services';
 import { toast } from 'react-toastify';
+import { VolunteerRole } from '../enums/VolunteerRole';
 
 interface IProps {
   onLogout(): void;
 }
 
 const HeaderComponent = (props: RouteComponentProps & IProps) => {
-  const [path, setPath] = useState('' as string);
+  const [path, setPath] = useState('');
+  const [subPath, setSubPath] = useState('');
+  const [onDropDown, setOnDropDown] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
 
-  const [subPath, setSubPath] = useState('' as string);
-
-  const [onDropDown, setOnDropDown] = useState<boolean>(false);
-
-  const [modalOpen, setModalOpen] = useState<boolean>(false);
-
-  const { queue, chats } = useContext(SocketContext);
-
+  const { queue, chats, volunteerInfo } = useContext(SocketContext);
   const {
     activeState,
     setActiveState,
@@ -128,13 +125,15 @@ const HeaderComponent = (props: RouteComponentProps & IProps) => {
           >
             <Link to="/profile">Min profil</Link>
           </li>
-          <li
-            className={`header--list-item ${path === 'admin' && 'active'}`}
-            onMouseOver={() => setOnDropDown(true)}
-            onClick={() => setPath('admin')}
-          >
-            Admin
-          </li>
+          {volunteerInfo.role === VolunteerRole.ADMIN && (
+            <li
+              className={`header--list-item ${path === 'admin' && 'active'}`}
+              onMouseOver={() => setOnDropDown(true)}
+              onClick={() => setPath('admin')}
+            >
+              Admin
+            </li>
+          )}
           <li
             className={`header--list-item ${path === 'logout' && 'active'}`}
             onClick={onLogout}
@@ -174,7 +173,7 @@ const HeaderComponent = (props: RouteComponentProps & IProps) => {
           </li>
         </ul>
       </div>
-      {onDropDown && (
+      {onDropDown && volunteerInfo.role === VolunteerRole.ADMIN && (
         <div
           className="header--dropdown"
           onMouseOver={() => setOnDropDown(true)}
@@ -188,8 +187,12 @@ const HeaderComponent = (props: RouteComponentProps & IProps) => {
             </li>
             <li
               className={`header--list-item ${subPath === 'users' && 'active'}`}
+              onClick={() => {
+                setPath('admin');
+                setSubPath('users');
+              }}
             >
-              <Link to="/questions">Administrer brukere</Link>
+              <Link to="/admin/users">Administrer brukere</Link>
             </li>
             <li
               className={`header--list-item ${subPath === 'topics' &&

--- a/src/components/ProfileFormComponent.tsx
+++ b/src/components/ProfileFormComponent.tsx
@@ -1,62 +1,64 @@
-import React, { FunctionComponent } from 'react';
-import { IProfile } from '../interfaces';
+import React, { FunctionComponent, useContext } from 'react';
+import { SocketContext } from '../providers';
 
 interface IProps {
-  profile: IProfile;
   title: string;
-  setProfile(value: IProfile): void;
   isChanged(value: boolean): void;
 }
 
 const ProfileFormContainer: FunctionComponent<IProps> = ({
-  profile,
-  setProfile,
   isChanged,
   title,
-}) => (
-  <div className="profile-form--container">
-    <h3>{title}</h3>
-    <form className="profile-form">
-      <label className="profile-form--item">
-        Navn
-        <input
-          className="profile-form--input"
-          value={profile.name}
-          type="text"
-          name="name"
-          onChange={e => {
-            isChanged(true);
-            setProfile({ ...profile, name: e.target.value });
-          }}
-        />
-      </label>
-      <label className="profile-form--item">
-        E-post
-        <input
-          className="profile-form--input"
-          value={profile.email}
-          type="email"
-          name="email"
-          onChange={e => {
-            isChanged(true);
-            setProfile({ ...profile, email: e.target.value });
-          }}
-        />
-      </label>
-      <label className="profile-form--item">
-        Bio
-        <textarea
-          className="profile-form--long-input"
-          value={profile.bioText}
-          name="bio"
-          onChange={e => {
-            isChanged(true);
-            setProfile({ ...profile, bioText: e.target.value });
-          }}
-        />
-      </label>
-    </form>
-  </div>
-);
+}) => {
+  const { setVolunteerInfo: setProfile, volunteerInfo: profile } = useContext(
+    SocketContext,
+  );
+
+  return (
+    <div className="profile-form--container">
+      <h3>{title}</h3>
+      <form className="profile-form">
+        <label className="profile-form--item">
+          Navn
+          <input
+            className="profile-form--input"
+            value={profile.name}
+            type="text"
+            name="name"
+            onChange={e => {
+              isChanged(true);
+              setProfile({ ...profile, name: e.target.value });
+            }}
+          />
+        </label>
+        <label className="profile-form--item">
+          E-post
+          <input
+            className="profile-form--input"
+            value={profile.email}
+            type="email"
+            name="email"
+            onChange={e => {
+              isChanged(true);
+              setProfile({ ...profile, email: e.target.value });
+            }}
+          />
+        </label>
+        <label className="profile-form--item">
+          Bio
+          <textarea
+            className="profile-form--long-input"
+            value={profile.bioText}
+            name="bio"
+            onChange={e => {
+              isChanged(true);
+              setProfile({ ...profile, bioText: e.target.value });
+            }}
+          />
+        </label>
+      </form>
+    </div>
+  );
+};
 
 export default ProfileFormContainer;

--- a/src/components/QuestionListComponent.tsx
+++ b/src/components/QuestionListComponent.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { IQuestionMeta } from '../interfaces';
+import { IQuestion } from '../interfaces';
 import { withRouter, RouteComponentProps } from 'react-router';
 import { dateStringFormat, studentGradeFormat } from '../services';
 
 interface IProps {
-  questionList: IQuestionMeta[];
+  questionList: IQuestion[];
   type: string;
 }
 const QuestionListComponent = (props: IProps & RouteComponentProps) => {

--- a/src/containers/AdminQuestionsContainer.tsx
+++ b/src/containers/AdminQuestionsContainer.tsx
@@ -13,8 +13,8 @@ const AdminQuestionsContainer = () => {
   );
 
   useEffect(() => {
-    getQuestionList<IQuestion[]>('public').then(setPublicQuestionList);
-    getQuestionList<IQuestion[]>('unpublished').then(setUnpublicQuestionList);
+    getQuestionList('public').then(setPublicQuestionList);
+    getQuestionList('unpublished').then(setUnpublicQuestionList);
   }, []);
 
   return (

--- a/src/containers/AdminUsersContainer.tsx
+++ b/src/containers/AdminUsersContainer.tsx
@@ -1,0 +1,64 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import AddUserComponent from '../components/AddUserComponent';
+import EditUsersComponent from '../components/EditUsersComponent';
+import { addUser, deleteUser, getUserList, updateUserRole } from '../services';
+import '../styles/admin-users.less';
+import { toast } from 'react-toastify';
+import { INewUser } from '../interfaces/INewUser';
+import { IVolunteer } from '../interfaces';
+
+const AdminUsersContainer = () => {
+  const [users, setUsers] = useState<IVolunteer[]>([]);
+
+  const refreshUsers = useCallback(() => {
+    getUserList().then(setUsers);
+  }, [setUsers]);
+
+  useEffect(refreshUsers, []);
+
+  const handleUpdateUserRole = useCallback(
+    async (id: string, role: string) => {
+      await updateUserRole(id, role);
+      refreshUsers();
+    },
+    [refreshUsers],
+  );
+
+  const handleAddUser = useCallback(
+    async (user: INewUser) => {
+      try {
+        await addUser(user);
+        refreshUsers();
+        toast.success(
+          `${user.name} har blitt lagt til som bruker med rollen ${user.role}.`,
+        );
+      } catch (error) {
+        toast.error(
+          'Brukeren kan ikke legges til. Vennligst kontakt IT-avdelingen.',
+        );
+      }
+    },
+    [refreshUsers],
+  );
+
+  const handleDeleteUser = useCallback(
+    async (id: string) => {
+      await deleteUser(id);
+      refreshUsers();
+    },
+    [refreshUsers],
+  );
+
+  return (
+    <div className="admin-users-container">
+      <AddUserComponent onAddUser={handleAddUser} />
+      <EditUsersComponent
+        users={users}
+        onUpdateUser={handleUpdateUserRole}
+        onDeleteUser={handleDeleteUser}
+      />
+    </div>
+  );
+};
+
+export default AdminUsersContainer;

--- a/src/containers/AnswerQuestionContainer.tsx
+++ b/src/containers/AnswerQuestionContainer.tsx
@@ -80,7 +80,7 @@ const AnswerQuestionContainer = (props: IProps & RouteComponentProps) => {
           ),
         });
       }
-      getSubjectList<ISubject[]>().then(data => {
+      getSubjectList().then(data => {
         const list = data
           .filter(e => e.subjectTitle === resquestion.subject)
           .flatMap(e => e.themes);

--- a/src/containers/QuestionContainer.tsx
+++ b/src/containers/QuestionContainer.tsx
@@ -1,14 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { getQuestionList, getQuestion, getFeedbackList } from '../services';
 import { QuestionListComponent, FeedbackListComponent } from '../components';
-import { IQuestionMeta, IFeedbackQuestion } from '../interfaces';
+import { IFeedbackQuestion, IQuestion } from '../interfaces';
 
 const QuestionContainer = () => {
-  const [inboxQuestions, setInboxQuestions] = useState<IQuestionMeta[]>([]);
-  const [startedQuestions, setStartedQuestions] = useState<IQuestionMeta[]>([]);
-  const [approvalQuestions, setAnsweredQuestions] = useState<IQuestionMeta[]>(
-    [],
-  );
+  const [inboxQuestions, setInboxQuestions] = useState<IQuestion[]>([]);
+  const [startedQuestions, setStartedQuestions] = useState<IQuestion[]>([]);
+  const [approvalQuestions, setAnsweredQuestions] = useState<IQuestion[]>([]);
   const [feedbackQuestions, setFeedbackQuestions] = useState<
     IFeedbackQuestion[]
   >([]);
@@ -37,13 +35,13 @@ const QuestionContainer = () => {
   };
 
   useEffect(() => {
-    getQuestionList<IQuestionMeta[]>('inbox')
+    getQuestionList('inbox')
       .then(setInboxQuestions)
       .catch(() => setApiFail(true));
-    getQuestionList<IQuestionMeta[]>('started')
+    getQuestionList('started')
       .then(setStartedQuestions)
       .catch(() => setApiFail(true));
-    getQuestionList<IQuestionMeta[]>('approval')
+    getQuestionList('approval')
       .then(setAnsweredQuestions)
       .catch(() => setApiFail(true));
     setFeedback();

--- a/src/containers/QuestionContainer.tsx
+++ b/src/containers/QuestionContainer.tsx
@@ -1,9 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import {
-  getQuestionList,
-  getQuestion,
-  getFeedbackList,
-} from '../services/api-service';
+import { getQuestionList, getQuestion, getFeedbackList } from '../services';
 import { QuestionListComponent, FeedbackListComponent } from '../components';
 import { IQuestionMeta, IFeedbackQuestion } from '../interfaces';
 

--- a/src/containers/index.ts
+++ b/src/containers/index.ts
@@ -1,5 +1,6 @@
 export { default as QuestionContainer } from './QuestionContainer';
 export { default as AnswerQuestionContainer } from './AnswerQuestionContainer';
 export { default as ChatContainer } from './ChatContainer';
+export { default as AdminUsersContainer } from './AdminUsersContainer';
 export { default as AdminQuestionsContainer } from './AdminQuestionsContainer';
 export { default as ProfileContainer } from './ProfileContainer';

--- a/src/enums/VolunteerRole.ts
+++ b/src/enums/VolunteerRole.ts
@@ -1,0 +1,4 @@
+export enum VolunteerRole {
+  ADMIN = 'ADMIN',
+  VOLUNTEER = 'VOLUNTEER',
+}

--- a/src/interfaces/INewUser.ts
+++ b/src/interfaces/INewUser.ts
@@ -1,0 +1,7 @@
+import { VolunteerRole } from '../enums/VolunteerRole';
+
+export interface INewUser {
+  name: string;
+  email: string;
+  role: VolunteerRole;
+}

--- a/src/interfaces/IProfile.ts
+++ b/src/interfaces/IProfile.ts
@@ -1,6 +1,0 @@
-export interface IProfile {
-  name: string;
-  email: string;
-  id: string;
-  bioText: string;
-}

--- a/src/interfaces/IQuestion.ts
+++ b/src/interfaces/IQuestion.ts
@@ -1,17 +1,14 @@
 import { IFile, ITheme } from '.';
 
-export interface IQuestion extends IQuestionMeta {
-  title: string;
-  questionText: string;
-  answerText;
-  isPublic: boolean;
-  files: IFile[];
-}
-
-export interface IQuestionMeta {
+export interface IQuestion {
   id: string;
   subject: string;
   questionDate: string;
   studentGrade: string;
   themes: ITheme[];
+  title: string;
+  questionText: string;
+  answerText;
+  isPublic: boolean;
+  files: IFile[];
 }

--- a/src/interfaces/IVolunteer.ts
+++ b/src/interfaces/IVolunteer.ts
@@ -1,3 +1,6 @@
+import { ISubject } from './ISubject';
+import { VolunteerRole } from '../enums/VolunteerRole';
+
 export interface IVolunteer {
   id: string;
   name: string;
@@ -5,4 +8,6 @@ export interface IVolunteer {
   email: string;
   imgUrl: string;
   chatID: string;
+  subjects?: ISubject[];
+  role?: VolunteerRole;
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -12,7 +12,6 @@ export * from './IChat';
 export * from './IAction';
 export * from './IFeedback';
 export * from './IVolunteerSubject';
-export * from './IProfile';
 export * from './IFile';
 export * from './ITempFile';
 export * from './ITalky';

--- a/src/providers/SocketProvider.tsx
+++ b/src/providers/SocketProvider.tsx
@@ -221,7 +221,7 @@ export const SocketProvider: FunctionComponent = ({ children }) => {
             opened: false,
           });
         }
-        getVolunteer().then((data: IVolunteer) => {
+        getVolunteer().then(data => {
           setVolunteerInfo(data);
           socketSend(createVolunteerMessage(data));
         });
@@ -229,7 +229,7 @@ export const SocketProvider: FunctionComponent = ({ children }) => {
       case CONNECTION:
         setUniqueID(payload['uniqueID']);
         setInterval(() => socketSend(createPingMessage()), 300000);
-        getVolunteer().then((data: IVolunteer) => {
+        getVolunteer().then(data => {
           setVolunteerInfo(data);
           socketSend(createVolunteerMessage(data));
         });
@@ -260,7 +260,7 @@ export const SocketProvider: FunctionComponent = ({ children }) => {
         toast.error('Det skjedde en feil. Du forlot ikke rommet.');
         break;
       case RECONNECT:
-        getVolunteer().then((data: IVolunteer) => {
+        getVolunteer().then(data => {
           setVolunteerInfo(data);
           socketSend(createVolunteerMessage(data));
         });

--- a/src/providers/SocketProvider.tsx
+++ b/src/providers/SocketProvider.tsx
@@ -36,7 +36,7 @@ import { IVolunteer } from '../interfaces';
 
 // Toast notification config (for entire App)
 toast.configure({
-  autoClose: 1500,
+  autoClose: 2000,
   draggable: false,
   position: 'top-center',
   closeButton: false,

--- a/src/providers/SocketProvider.tsx
+++ b/src/providers/SocketProvider.tsx
@@ -56,14 +56,31 @@ const getSocket = (): WebSocket => {
   return socket;
 };
 
-export const SocketContext = createContext({
+interface ISocketState {
+  uniqueID: string;
+  chats: IChat[];
+  queue: IStudent[];
+  activeChatIndex: number;
+  talky: ITalky | null;
+  availableVolunteers: IVolunteer[];
+  volunteerInfo: IVolunteer;
+
+  dispatchChats(_: IAction): void;
+  setQueue(_: IStudent[]): void;
+  socketSend(_: ISocketMessage | IGetMessage): void;
+  setActiveChatIndex(_: number): void;
+  setVolunteerInfo(_: IVolunteer): void;
+  setAvailableVolunteers(_: IVolunteer[]): void;
+}
+
+export const SocketContext = createContext<ISocketState>({
   // Values available with context
-  uniqueID: '' as string,
+  uniqueID: '',
   chats: [{}] as IChat[],
-  queue: [] as IStudent[],
-  activeChatIndex: 0 as number,
-  talky: null as null | ITalky,
-  availableVolunteers: [] as IVolunteer[],
+  queue: [],
+  activeChatIndex: 0,
+  talky: null,
+  availableVolunteers: [],
   volunteerInfo: {
     id: '',
     name: '',
@@ -82,7 +99,7 @@ export const SocketContext = createContext({
   setAvailableVolunteers(vols: IVolunteer[]): void {},
 });
 
-export const SocketProvider: FunctionComponent = ({ children }: any) => {
+export const SocketProvider: FunctionComponent = ({ children }) => {
   const [chats, dispatchChats] = useReducer(chatReducer, []);
   const [activeChatIndex, setActiveChatIndex] = useState<number>(0);
   const [uniqueID, setUniqueID] = useState<string>('');

--- a/src/providers/StateProvider.tsx
+++ b/src/providers/StateProvider.tsx
@@ -8,7 +8,7 @@ export const StateContext = createContext({
   setIsLeksehjelpOpen(bool: boolean): void {},
 });
 
-export const StateProvider = ({ children }: any) => {
+export const StateProvider: React.FC = ({ children }) => {
   const [activeState, setActiveState] = useState<boolean>(false);
   const [isLeksehjelpOpen, setIsLeksehjelpOpen] = useState<boolean>(false);
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -14,6 +14,7 @@ import {
   AdminUsersContainer,
   ProfileContainer,
 } from './containers';
+import AdminRoute from './components/AdminRoute';
 
 interface IProps {
   onLogout(): void;
@@ -37,9 +38,9 @@ const Routes = ({ onLogout }: IProps) => {
             />
           )}
         />
-        <Route exact path="/admin/users" component={AdminUsersContainer} />
-        <Route
-          exaxt
+        <AdminRoute exact path="/admin/users" component={AdminUsersContainer} />
+        <AdminRoute
+          exact
           path="/admin/questions"
           component={AdminQuestionsContainer}
         />

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -11,6 +11,7 @@ import {
   AnswerQuestionContainer,
   ChatContainer,
   AdminQuestionsContainer,
+  AdminUsersContainer,
   ProfileContainer,
 } from './containers';
 
@@ -36,6 +37,7 @@ const Routes = ({ onLogout }: IProps) => {
             />
           )}
         />
+        <Route exact path="/admin/users" component={AdminUsersContainer} />
         <Route
           exaxt
           path="/admin/questions"

--- a/src/services/api-service.ts
+++ b/src/services/api-service.ts
@@ -4,9 +4,12 @@ import {
   IQuestion,
   IAnswer,
   IFeedbackQuestion,
-  IProfile,
   IOpen,
+  ISubject,
+  IVolunteer,
+  IVolunteerSubject,
 } from '../interfaces';
+import { INewUser } from '../interfaces/INewUser';
 
 const api = axios.create({
   baseURL:
@@ -21,29 +24,27 @@ export function getQuestion(id: string): Promise<IQuestion> {
     .catch(err => err);
 }
 
-export async function getFeedbackList(
-  id?: string,
-): Promise<IFeedbackQuestion[]> {
-  return await api
+export function getFeedbackList(id?: string): Promise<IFeedbackQuestion[]> {
+  return api
     .get(id ? `feedback/question/${id}` : 'feedback')
     .then(res => res.data);
 }
 
-export async function getIsLeksehjelpOpen<T>(): Promise<IOpen> {
+export function getIsLeksehjelpOpen(): Promise<IOpen> {
   return api
     .get('isopen')
     .then(res => res.data)
     .catch(e => console.error(e.getMessage));
 }
 
-export async function toggleIsLeksehjelpOpen<T>(): Promise<IOpen> {
+export function toggleIsLeksehjelpOpen(): Promise<IOpen> {
   return api
     .post('isopen')
     .then(res => res.data)
     .catch(e => console.error(e.getMessage));
 }
 
-export async function getQuestionList<T>(parameter?: string): Promise<T> {
+export function getQuestionList(parameter?: string): Promise<IQuestion[]> {
   let state = '';
   switch (parameter) {
     case 'inbox':
@@ -65,38 +66,32 @@ export async function getQuestionList<T>(parameter?: string): Promise<T> {
       state = '';
       break;
   }
-  const response = await api.get(
-    parameter !== undefined
-      ? `questions?includeAll=true${state}`
-      : 'questions?includeAll=true',
-  );
 
-  return response.data;
+  return api
+    .get(
+      parameter !== undefined
+        ? `questions?includeAll=true${state}`
+        : 'questions?includeAll=true',
+    )
+    .then(res => res.data);
 }
 
-export async function getVolunteerSubjectList<T>(): Promise<T> {
-  return await api.get('volunteers/subjects').then(res => res.data);
+export function getVolunteerSubjectList(): Promise<IVolunteerSubject[]> {
+  return api.get('volunteers/subjects').then(res => res.data);
 }
 
-export async function getVolunteerProfile<T>(): Promise<T> {
-  return await api.get('volunteers/self').then(res => res.data);
+export function getSubjectList(): Promise<ISubject[]> {
+  return api.get<ISubject[]>('subjects').then(res => res.data);
 }
 
-export async function getSubjectList<T>(): Promise<T> {
-  return await api.get('subjects').then(res => res.data);
+export function getMestringSubjectList(): Promise<ISubject[]> {
+  return api.get('subjects?isMestring=1').then(res => res.data);
 }
 
-export async function getMestringSubjectList<T>(): Promise<T> {
-  return await api.get('subjects?isMestring=1').then(res => res.data);
+export function getVolunteer(): Promise<IVolunteer> {
+  return api.get('volunteers/self').then(res => res.data);
 }
-
-export async function getVolunteer<T>(): Promise<T> {
-  return await api.get('volunteers/self').then(res => res.data);
-}
-export async function postAnswer(
-  data: IAnswer,
-  type?: string,
-): Promise<IQuestion> {
+export function postAnswer(data: IAnswer, type?: string): Promise<IQuestion> {
   const { questionId } = data;
   let body = {};
   switch (type) {
@@ -122,19 +117,38 @@ export async function postAnswer(
       body = { ...data, state: 2 };
       break;
   }
-  return await api.post(`questions/${questionId}`, body).then(res => res.data);
+  return api.post(`questions/${questionId}`, body).then(res => res.data);
 }
 
-export async function deleteFeedback(id: string): Promise<{}> {
-  return await api.post(`feedback/${id}/delete`).then(res => res.data);
+export function deleteFeedback(id: string): Promise<void> {
+  return api.post(`feedback/${id}/delete`);
 }
 
-export async function saveSubjects(list: number[]): Promise<{}> {
-  return await api
-    .post('volunteers/subjects', { subjects: list })
+export function saveSubjects(list: number[]): Promise<void> {
+  return api.post('volunteers/subjects', { subjects: list });
+}
+
+export function updateProfile(profile?: IVolunteer): Promise<void> {
+  return api.post('volunteers', profile);
+}
+
+export function getUserList(): Promise<IVolunteer[]> {
+  return api.get('volunteers').then(res => res.data);
+}
+
+export function updateUserRole(
+  userId: string,
+  role: string,
+): Promise<[{ role: string }]> {
+  return api
+    .post(`admin/volunteerrole/${userId}`, { role })
     .then(res => res.data);
 }
 
-export async function updateProfile(profil: IProfile): Promise<{}> {
-  return await api.post('volunteers', profil).then(res => res.data);
+export function addUser(user: INewUser): Promise<void> {
+  return api.post('admin/volunteer', user);
+}
+
+export function deleteUser(id: string): Promise<void> {
+  return api.delete(`admin/volunteer/${id}`);
 }

--- a/src/services/util-service.ts
+++ b/src/services/util-service.ts
@@ -1,4 +1,5 @@
 import GRADES from '../grades';
+import { VolunteerRole } from '../enums/VolunteerRole';
 
 export const studentGradeFormat = (studentGrade: string): string => {
   if (Number(studentGrade) > 7 || Number(studentGrade) < 14) {
@@ -8,3 +9,14 @@ export const studentGradeFormat = (studentGrade: string): string => {
   }
   return studentGrade;
 };
+
+const roleMap = {
+  [VolunteerRole.ADMIN]: 'Admin',
+  [VolunteerRole.VOLUNTEER]: 'Frivillig',
+};
+
+export const getRoleOptions = () =>
+  Object.values(VolunteerRole).map(role => ({
+    label: roleMap[role],
+    value: role,
+  }));

--- a/src/styles/admin-users.less
+++ b/src/styles/admin-users.less
@@ -1,0 +1,76 @@
+.admin-users-container {
+  display: flex;
+  flex-direction: column;
+  max-width: 800px;
+  width: 70vw;
+  margin-left: 2rem;
+}
+
+.add-users {
+  display: flex;
+  flex-direction: column;
+  margin-top: 2rem;
+  max-width: 400px;
+
+  &--title {
+    margin-bottom: 1rem;
+  }
+
+  &--fields {
+    display: flex;
+    flex-direction: column;
+    margin-left: 0.5rem;
+  }
+
+  &--item {
+    margin-top: 0.5rem;
+  }
+
+  &--button {
+    max-width: 100px;
+    align-self: flex-end;
+  }
+}
+
+.edit-users {
+  margin-top: 2rem;
+  width: 100%;
+
+  &--title {
+    margin-bottom: 1rem;
+  }
+
+  &--header {
+    text-align: left;
+    padding-bottom: 0.5rem;
+    padding-top: 0.5rem;
+    border-top: thin solid black;
+  }
+
+  &&--row {
+    border-bottom: thin solid black;
+    text-align: left;
+
+    &--item {
+      width: 20vw;
+    }
+  }
+}
+
+.w60 {
+  max-width: 60px;
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+th {
+  font-weight: normal;
+  text-align: left;
+}
+
+tr {
+  border-bottom: thin solid black;
+}

--- a/src/styles/base.less
+++ b/src/styles/base.less
@@ -119,6 +119,7 @@ button {
 
 .leksehjelp--dropdown {
   background-color: @white;
+  cursor: pointer;
 }
 
 .leksehjelp--button {
@@ -127,6 +128,11 @@ button {
     &:hover {
       background-color: @link-hover-color;
     }
+  }
+
+  &-disabled {
+    background-color: @disabled-color;
+    cursor: default;
   }
 
   &-warning {


### PR DESCRIPTION
## What's changed ##
- Add new components: `AdminUsersContainer`, `AddUserComponent`, `EditUsersComponent`, `EditUserRow`
- Add endpoints for removing, adding and updating a volunteer
- Increase type safety by matching interfaces with responses from API
- Make header show Admin page only if user is admin (`HeaderComponent.tsx`)
- Create `AdminRoute` which restrict admin specific paths
- Refactor code in `ProfileFormComponent`, `QuestionListComponent`, `api-service`, ..